### PR TITLE
Add key for settingsFile to Postman Body

### DIFF
--- a/API Security Tester.postman_collection.json
+++ b/API Security Tester.postman_collection.json
@@ -61,7 +61,7 @@
 					"formdata": [
 						{
 							"key": "collectionFile",
-							"description": "Postman collection referencing the API you wish to test",
+							"description": "Postman collection referencing the API you wish to test.  Please ensure the file is either in the Postman preference 'Working directory' or set Postman 'Allow reading files outside working directory' preference to On.",
 							"type": "file",
 							"src": []
 						},
@@ -73,7 +73,13 @@
 						},
 						{
 							"key": "environmentFile",
-							"description": "(optional) Postman evironment file",
+							"description": "(optional) Postman evironment file.  Please ensure the file is either in the Postman preference 'Working directory' or set Postman 'Allow reading files outside working directory' preference to On.",
+							"type": "file",
+							"src": []
+						},
+						{
+							"key": "scanSettings",
+							"description": "(optional) IDD Scan settings file.  Please ensure the file is either in the Postman preference 'Working directory' or set Postman 'Allow reading files outside working directory' preference to On.",
 							"type": "file",
 							"src": []
 						}


### PR DESCRIPTION
I206 Add key for settingsFile to Postman Body
This adds a settingsFile key to the Postman body to allow
uploading of IDD related settings.  Updates other File
key descriptions to alert user to need to use Postman
'Working Directory' or to set 'Allow reading files outside
working directory' preference to On.